### PR TITLE
Functionality and test coverage

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,6 +21,7 @@
     "test"
   ],
   "dependencies": {
+    "iron-ajax": "PolymerElements/iron-ajax#^1.0.0",
     "polymer": "Polymer/polymer#^1.0.0"
   },
   "devDependencies": {

--- a/rise-logger-utils.html
+++ b/rise-logger-utils.html
@@ -1,0 +1,104 @@
+<link rel="import" href="../polymer/polymer.html">
+
+<!--
+`rise-logger-utils` is a web component that is a utilities helper for `rise-logger`.
+
+-->
+
+<script>
+  (function() {
+    /* global Polymer */
+    /* jshint newcap: false */
+
+    "use strict";
+
+    var USAGE_DEV = "dev",
+      USAGE_STANDALONE = "standalone",
+      USAGE_WIDGET = "widget";
+
+    Polymer({
+      is: "rise-logger-utils",
+
+      hostAttributes: {
+        hidden: true
+      },
+
+      _getSuffix: function() {
+        var date = new Date(),
+          year = date.getUTCFullYear(),
+          month = date.getUTCMonth() + 1,
+          day = date.getUTCDate();
+
+        if (month < 10) {
+          month = "0" + month;
+        }
+
+        if (day < 10) {
+          day = "0" + day;
+        }
+
+        return year + month + day;
+      },
+
+      _getUsageType: function(href) {
+        var a = document.createElement("a"),
+          type = USAGE_STANDALONE;
+
+        a.href = href;
+
+        if (a.hostname === "localhost") {
+          type = USAGE_DEV;
+        }
+        else if (a.hostname === "s3.amazonaws.com" && a.pathname.indexOf("widget-") > -1) {
+          type = USAGE_WIDGET;
+        }
+
+        return type;
+      },
+
+      /**
+       * Gets the data to use in the body of the POST request to Big Query
+       *
+       */
+      getInsertData: function(params) {
+        var BASE_INSERT_SCHEMA = {
+            "kind": "bigquery#tableDataInsertAllRequest",
+            "skipInvalidRows": false,
+            "ignoreUnknownValues": false,
+            "templateSuffix": this._getSuffix(),
+            "rows": [{
+              "insertId": ""
+            }]
+          },
+          data = JSON.parse(JSON.stringify(BASE_INSERT_SCHEMA));
+
+        data.rows[0].insertId = Math.random().toString(36).substr(2).toUpperCase();
+        data.rows[0].json = JSON.parse(JSON.stringify(params));
+        data.rows[0].json.ts = new Date().toISOString();
+
+        return data;
+      },
+
+      /**
+       * Gets the params to use in the POST request to Big Query
+       *
+       */
+      getInsertParams: function(params) {
+        var json = null;
+
+        // event is required.
+        if (params.event) {
+          // clone params
+          json = JSON.parse(JSON.stringify(params));
+
+          // add the usage type
+          json.usage_type = this._getUsageType(window.location.href);
+        }
+
+        return json;
+      }
+
+    });
+
+  })();
+</script>

--- a/rise-logger.html
+++ b/rise-logger.html
@@ -1,4 +1,6 @@
 <link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="rise-logger-utils.html">
+<link rel="import" href="../iron-ajax/iron-ajax.html">
 
 <!--
 `rise-logger` is a web component that is used for logging usage of a parent web component.
@@ -7,6 +9,15 @@
 -->
 <dom-module id="rise-logger">
   <template>
+    <rise-logger-utils id="utils"></rise-logger-utils>
+    <iron-ajax id="token"
+               method="POST"
+               handle-as="json"
+               on-response="_onTokenResponse">
+    </iron-ajax>
+    <iron-ajax id="insert"
+               method="POST">
+    </iron-ajax>
     <content></content>
   </template>
 </dom-module>
@@ -18,10 +29,133 @@
 
     "use strict";
 
+    var LOGGER_CLIENT_ID = "1088527147109-6q1o2vtihn34292pjt4ckhmhck0rk0o7.apps.googleusercontent.com",
+      LOGGER_CLIENT_SECRET = "nlZyrcPLg6oEwO9f9Wfn29Wh",
+      LOGGER_REFRESH_TOKEN = "1/xzt4kwzE1H7W9VnKB8cAaCx6zb4Es4nKEoqaYHdTD15IgOrJDtdun6zK6XiATCKT";
+
     Polymer({
       is: "rise-logger",
 
-      properties: {}
+      hostAttributes: {
+        hidden: true
+      },
+
+      properties: {
+        tableName: {
+          type: String,
+          readOnly: true,
+          value: ""
+        },
+        params: {
+          type: Object,
+          readOnly: true,
+          value: function() { return {}; }
+        }
+      },
+
+      _throttle: false,
+
+      _throttleDelay: 1000,
+
+      _lastEvent: "",
+
+      _refreshDate: 0,
+
+      _token: "",
+
+      _isThrottled: function(event) {
+        return this._throttle && (this._lastEvent === event);
+      },
+
+      _getInsertHeaders: function(token) {
+        return {
+          "Content-Type": "application/json",
+          "Authorization": "Bearer " + token
+        };
+      },
+
+      _getInsertURL: function() {
+        var serviceUrl = "https://www.googleapis.com/bigquery/v2/projects/client-side-events/datasets/Widget_Events/tables/TABLE_ID/insertAll";
+
+        return serviceUrl.replace("TABLE_ID", this.tableName);
+      },
+
+      _insert: function(refreshData) {
+        this._refreshDate = refreshData.refreshedAt || this._refreshDate;
+        this._token = refreshData.token || this._token;
+
+        this.$.insert.url = this._getInsertURL();
+        this.$.insert.headers = this._getInsertHeaders(this._token);
+        this.$.insert.body = JSON.stringify(this.$.utils.getInsertData(this.params));
+
+        this.$.insert.generateRequest();
+      },
+
+      _onTokenResponse: function(e, resp) {
+        // in case there are other instances of rise-logger
+        e.stopPropagation();
+
+        if (resp && resp.response) {
+          this._insert({ token: resp.response.access_token, refreshedAt: new Date() });
+        }
+      },
+
+      _getTokenParams: function() {
+        var params = {};
+
+        params.client_id = LOGGER_CLIENT_ID;
+
+        params.client_secret = LOGGER_CLIENT_SECRET;
+
+        params.refresh_token = LOGGER_REFRESH_TOKEN;
+
+        params.grant_type = "refresh_token";
+
+        return params;
+      },
+
+      _refreshToken: function () {
+        if (new Date() - this._refreshDate < 3580000) {
+          return this._insert({});
+        }
+
+        this.$.token.url = "https://www.googleapis.com/oauth2/v3/token";
+        this.$.token.params = this._getTokenParams();
+
+        this.$.token.generateRequest();
+      },
+
+      /**
+       * Logs data to Google Big Query
+       *
+       */
+      log: function(tableName, params) {
+        var self = this,
+          insertParams;
+
+        if (!tableName || !params || (params.hasOwnProperty("event") && !params.event) ||
+          (params.hasOwnProperty("event") && this._isThrottled(params.event))) {
+          return;
+        }
+
+        insertParams = this.$.utils.getInsertParams(params);
+
+        if (!insertParams || insertParams.usage_type === "dev") {
+          return;
+        }
+
+        this._throttle = true;
+        this._lastEvent = params.event;
+
+        this._setTableName(tableName);
+        this._setParams(insertParams);
+
+        this.debounce("throttle", function () {
+          self._throttle = false;
+        }, this._throttleDelay);
+
+        this._refreshToken();
+      }
 
     });
 

--- a/test/index.html
+++ b/test/index.html
@@ -11,7 +11,9 @@
 <body>
 <script>
   WCT.loadSuites([
-    // TODO: tests to come
+    "rise-logger-unit.html",
+    "rise-logger-utils-unit.html",
+    "rise-logger-integration.html"
   ]);
 </script>
 </body>

--- a/test/rise-logger-integration.html
+++ b/test/rise-logger-integration.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+  <title>rise-logger</title>
+
+  <script src="../bower_components/webcomponentsjs/webcomponents.min.js"></script>
+  <script src="../bower_components/web-component-tester/browser.js"></script>
+
+  <link rel="import" href="../rise-logger.html">
+</head>
+<body>
+
+<rise-logger id="logger"></rise-logger>
+
+<script>
+  suite("rise-logger", function () {
+    var xhr, clock, requests,
+      logger = document.querySelector("#logger"),
+      tableName = "test",
+      interval = 3580000,
+      token = "my-token",
+      data = { "access_token": token },
+      json = JSON.stringify(data),
+      params = {
+        "event": "ready"
+      };
+
+    suiteSetup(function() {
+      requests = [];
+
+      xhr = sinon.useFakeXMLHttpRequest();
+
+      xhr.onCreate = function (xhr) {
+        requests.push(xhr);
+      };
+
+      clock = sinon.useFakeTimers();
+
+      sinon.stub(logger.$.utils, "_getUsageType", function() {
+        return "standalone";
+      });
+
+      sinon.stub(logger, "_refreshToken", function () {
+        logger._onTokenResponse({
+          "stopPropagation": function () {}
+        }, {
+          "response": data
+        })
+      });
+    });
+
+    suiteTeardown(function() {
+      xhr.restore();
+      clock.restore();
+      logger.$.utils._getUsageType.restore();
+      logger._refreshToken.restore();
+    });
+
+    setup(function() {
+      requests = [];
+
+      clock.tick(interval);
+      logger.log(tableName, params);
+
+      requests[0].respond(200, { "Content-Type": "text/json" }, JSON.stringify({"kind": "bigquery#tableDataInsertAllResponse"}));
+    });
+
+    function getDateSuffix() {
+      var date = new Date(),
+        year = date.getUTCFullYear(),
+        month = date.getUTCMonth() + 1,
+        day = date.getUTCDate();
+
+      if (month < 10) {
+        month = "0" + month;
+      }
+
+      if (day < 10) {
+        day = "0" + day;
+      }
+
+      return year + month + day;
+    }
+
+    test("should make a POST request", function() {
+      assert.equal(requests[0].method, "POST");
+    });
+
+    test("should make a request to the correct URL", function() {
+      assert.include(requests[0].url, "https://www.googleapis.com/bigquery/v2/projects/client-side-events/datasets/Widget_Events/tables/test");
+      assert.include(requests[0].url, "/insertAll");
+    });
+
+    test("should set the Content-Type header", function() {
+      assert.equal(requests[0].requestHeaders["content-type"], "application/json;charset=utf-8");
+    });
+
+    test("should set the Authorization header", function() {
+      assert.equal(requests[0].requestHeaders.authorization, "Bearer " + token);
+    });
+
+    test("should send string data in the body", function() {
+      assert.include(requests[0].requestBody, '{"kind":"bigquery#tableDataInsertAllRequest","skipInvalidRows":false,' +
+        '"ignoreUnknownValues":false,"templateSuffix":"' + getDateSuffix() + '","rows":[{"insertId":');
+      assert.include(requests[0].requestBody, '"json":{"event":"' + params.event + '","usage_type":"standalone","ts":');
+    });
+
+  });
+</script>
+</body>
+</html>

--- a/test/rise-logger-unit.html
+++ b/test/rise-logger-unit.html
@@ -1,0 +1,243 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+  <title>rise-logger</title>
+
+  <script src="../bower_components/webcomponentsjs/webcomponents.min.js"></script>
+  <script src="../bower_components/web-component-tester/browser.js"></script>
+
+  <link rel="import" href="../rise-logger.html">
+</head>
+<body>
+
+<rise-logger id="logger"></rise-logger>
+
+<script>
+  suite("rise-logger", function () {
+    var clock,
+      logger = document.querySelector("#logger");
+
+    suiteSetup(function() {
+      clock = sinon.useFakeTimers();
+    });
+
+    suiteTeardown(function() {
+      clock.restore();
+    });
+
+    suite("_isThrottled", function () {
+
+      suiteTeardown(function () {
+        logger._throttle = false;
+        logger._lastEvent = "";
+      });
+
+      test("should return false if last event is not throttled", function () {
+        assert.isFalse(logger._isThrottled(""));
+      });
+
+      test("should return true if last event is throttled", function () {
+        logger._throttle = true;
+        logger._lastEvent = "usage";
+
+        assert.isTrue(logger._isThrottled("usage"));
+      });
+
+    });
+
+    suite("_getInsertHeaders", function () {
+      var headers,
+        insertHeaders = {
+          "Content-Type": "application/json",
+          "Authorization": "Bearer my-token"
+        };
+
+      test("should return correct URL to use for making the insert request", function () {
+        headers = logger._getInsertHeaders("my-token");
+
+        assert.isObject(headers);
+        assert.deepEqual(headers, insertHeaders);
+      });
+    });
+
+    suite("_getInsertUrl", function () {
+      var url,
+        insertUrl = "https://www.googleapis.com/bigquery/v2/projects/client-side-events/datasets/Widget_Events/tables/image_events/insertAll";
+
+      suiteTeardown(function () {
+        logger._setTableName("");
+      });
+
+      test("should return correct URL to use for making the insert request", function () {
+        logger._setTableName("image_events");
+
+        url = logger._getInsertURL();
+
+        assert.isString(url);
+        assert.equal(url, insertUrl);
+      });
+    });
+
+    suite("_onTokenResponse", function () {
+      var insertStub;
+
+      var resp = {
+          "response": {
+            "access_token": "my-token"
+          }
+        },
+        e = {
+          "stopPropagation": function () {}
+        };
+
+      setup(function () {
+        insertStub = sinon.stub(logger, "_insert");
+      });
+
+      teardown(function () {
+        insertStub.restore();
+      });
+
+      test("should call _insert function with correct values", function () {
+        logger._onTokenResponse(e, resp);
+
+        assert.isTrue(insertStub.calledWith({token: resp.response.access_token, refreshedAt: clock.Date()}));
+      });
+
+    });
+
+    suite("_getTokenParams", function() {
+      var params,
+        tokenParams = {
+          client_id: "1088527147109-6q1o2vtihn34292pjt4ckhmhck0rk0o7.apps.googleusercontent.com",
+          client_secret: "nlZyrcPLg6oEwO9f9Wfn29Wh",
+          refresh_token: "1/xzt4kwzE1H7W9VnKB8cAaCx6zb4Es4nKEoqaYHdTD15IgOrJDtdun6zK6XiATCKT",
+          grant_type: "refresh_token"
+        };
+
+      test("should return an object with correct params", function () {
+        params = logger._getTokenParams();
+
+        assert.deepEqual(params, tokenParams);
+      });
+
+    });
+
+    suite("log", function() {
+      var refreshStub,
+        params = {
+          "event": "refresh"
+        };
+
+      function insertDev(params) {
+        return {
+          "event": params.event,
+          "usage_type": "dev"
+        };
+      }
+
+      function insertStandalone(params) {
+        return {
+          "event": params.event,
+          "usage_type": "standalone"
+        };
+      }
+
+      setup(function() {
+        refreshStub = sinon.stub(logger, "_refreshToken");
+      });
+
+      teardown(function() {
+        refreshStub.restore();
+        logger._throttle = false;
+        logger._lastEvent = "";
+      });
+
+      test("should not make a request if table name is empty", function() {
+        logger.log("", {
+          "event": "refresh"
+        });
+
+        assert.equal(refreshStub.callCount, 0);
+      });
+
+      test("should not make a request if no params provided", function() {
+        logger.log("component_sheet_events");
+
+        assert.equal(refreshStub.callCount, 0);
+      });
+
+      test("should not make a request if event is empty", function() {
+        logger.log("component_sheet_events", {
+          "event": ""
+        });
+
+        assert.equal(refreshStub.callCount, 0);
+      });
+
+      test("should not make a request if event is throttled", function() {
+        logger._throttle = true;
+        logger._lastEvent = "ready";
+
+        logger.log("component_sheet_events", {
+          "event": "ready"
+        });
+
+        assert.equal(refreshStub.callCount, 0);
+      });
+
+      test("should not make a request if usage type is 'dev'", function() {
+        var getInsertStub = sinon.stub(logger.$.utils, "getInsertParams", insertDev);
+
+        logger.log("component_sheet_events", {
+          "event": "ready"
+        });
+
+        assert.equal(refreshStub.callCount, 0);
+
+        getInsertStub.restore();
+      });
+
+      test("should not log the same event multiple times if the time between calls is less than 1 second", function() {
+        var getInsertStub = sinon.stub(logger.$.utils, "getInsertParams", insertStandalone);
+
+        logger.log("component_sheet_events", {"event": "ready"});
+        clock.tick(500);
+        logger.log("component_sheet_events", {"event": "ready"});
+
+        assert.equal(refreshStub.callCount, 1);
+
+        getInsertStub.restore();
+      });
+
+      test("should log the same event multiple times if the time between calls is over 1 second", function() {
+        var getInsertStub = sinon.stub(logger.$.utils, "getInsertParams", insertStandalone);
+
+        logger.log("component_sheet_events", {"event": "ready"});
+        clock.tick(1500);
+        logger.log("component_sheet_events", {"event": "ready"});
+
+        assert.equal(refreshStub.callCount, 2);
+
+        getInsertStub.restore();
+      });
+
+      test("should log different events if the time between calls is less than 1 second", function() {
+        var getInsertStub = sinon.stub(logger.$.utils, "getInsertParams", insertStandalone);
+
+        logger.log("component_sheet_events", {"event": "ready"});
+        logger.log("component_sheet_events", {"event": "test"});
+
+        assert.equal(refreshStub.callCount, 2);
+
+        getInsertStub.restore();
+      });
+
+    });
+
+  });
+</script>
+</body>
+</html>

--- a/test/rise-logger-utils-unit.html
+++ b/test/rise-logger-utils-unit.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+  <title>rise-logger-utils</title>
+
+  <script src="../bower_components/webcomponentsjs/webcomponents.min.js"></script>
+  <script src="../bower_components/web-component-tester/browser.js"></script>
+
+  <link rel="import" href="../rise-logger-utils.html">
+</head>
+<body>
+
+<rise-logger-utils id="utils"></rise-logger-utils>
+
+<script>
+  suite("rise-logger-utils", function () {
+    var utils = document.querySelector("#utils");
+
+    suite("_getUsageType", function () {
+
+      test("should return 'dev' when localhost detected", function () {
+        assert.equal(utils._getUsageType("http://localhost:8000/#/preview/widget"), "dev");
+      });
+
+      test("should return 'widget'", function () {
+        assert.equal(utils._getUsageType("http://s3.amazonaws.com/widget-google-spreadsheet/2.0.0/dist/widget.html"), "widget");
+      });
+
+      test("should return 'standalone'", function () {
+        assert.equal(utils._getUsageType("https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/test/content.html"), "standalone");
+      });
+
+    });
+
+    suite("getInsertData", function () {
+
+      var data = null,
+        params = {
+          "event": "ready",
+          "event_details": "testing",
+          "usage_type": "standalone",
+          "display_id": "abc123"
+        };
+
+      suiteSetup(function() {
+        data = utils.getInsertData(params);
+      });
+
+      test("should return an object containing insertId property", function() {
+        assert.property(data.rows[0], "insertId");
+        assert.isString(data.rows[0].insertId);
+      });
+
+      test("should return an object containing event property", function() {
+        assert.property(data.rows[0].json, "event");
+        assert.isString(data.rows[0].json.event);
+        assert.equal(data.rows[0].json.event, params.event);
+      });
+
+      test("should return an object containing event_details property", function() {
+        assert.property(data.rows[0].json, "event_details");
+        assert.isString(data.rows[0].json.event_details);
+        assert.equal(data.rows[0].json.event_details, params.event_details);
+      });
+
+      test("should return an object containing usage_type property", function() {
+        assert.property(data.rows[0].json, "usage_type");
+        assert.isString(data.rows[0].json.usage_type);
+        assert.equal(data.rows[0].json.usage_type, params.usage_type);
+      });
+
+      test("should return an object containing display_id property", function() {
+        expect(data.rows[0].json.display_id).to.exist;
+        expect(data.rows[0].json.display_id).to.be.a("string");
+        expect(data.rows[0].json.display_id).to.equal(params.display_id);
+      });
+
+      test("should return an object containing ts property", function() {
+        expect(data.rows[0].json.ts).to.exist;
+        expect(data.rows[0].json.ts).to.be.a("string");
+      });
+
+    });
+
+    suite("getInsertParams", function () {
+
+      test("should return null when event param missing", function () {
+        assert.isNull(utils.getInsertParams({"event_details": "test"}));
+      });
+
+      test("should return correct params including usage_type", function () {
+        var data;
+
+        sinon.stub(utils, "_getUsageType", function () { return "standalone"});
+
+        data = utils.getInsertParams({event: "ready", display_id: "abc123"});
+
+        assert.deepEqual(data, {
+          event: "ready",
+          usage_type: "standalone",
+          display_id: "abc123"
+        });
+
+        utils._getUsageType.restore();
+      });
+
+    });
+
+  });
+</script>
+</body>
+</html>


### PR DESCRIPTION
- `tableName` and `params` read-only properties
- `log` is the only public method
- "usage_type" property always added to params, determined to be either "dev", "widget", or "standalone"
- no request is made if usage type determined to be "dev" (finds "localhost" in window location href)
- rise-logger-utils component provides utility functions
- unit and integration tests added
