### PR TITLE
Using Rise Cache to retrieve and log display id

### DIFF
--- a/rise-logger-utils.html
+++ b/rise-logger-utils.html
@@ -83,13 +83,16 @@
        * Gets the params to use in the POST request to Big Query
        *
        */
-      getInsertParams: function(params) {
+      getInsertParams: function(params, displayId) {
         var json = null;
 
         // event is required.
         if (params.event) {
           // clone params
           json = JSON.parse(JSON.stringify(params));
+
+          // add the display id
+          json.display_id = displayId;
 
           // add the usage type
           json.usage_type = this._getUsageType(window.location.href);

--- a/rise-logger.html
+++ b/rise-logger.html
@@ -10,6 +10,13 @@
 <dom-module id="rise-logger">
   <template>
     <rise-logger-utils id="utils"></rise-logger-utils>
+    <iron-ajax id="displayId"
+               url="//localhost:9494/displays"
+               handle-as="json"
+               on-response="_onDisplayIdResponse"
+               on-error="_onDisplayIdError"
+               verbose="true">
+    </iron-ajax>
     <iron-ajax id="token"
                method="POST"
                handle-as="json"
@@ -53,6 +60,12 @@
         }
       },
 
+      _logWaiting: null,
+
+      _displayId: "",
+
+      _displayIdReceived: false,
+
       _throttle: false,
 
       _throttleDelay: 1000,
@@ -91,6 +104,26 @@
         this.$.insert.generateRequest();
       },
 
+      _onDisplayIdResponse: function(e, resp) {
+        if (resp.response && resp.response !== "") {
+          this._displayId = resp.response.displayId;
+        }
+
+        this._displayIdReceived = true;
+
+        if (this._logWaiting) {
+          this.log(this._logWaiting.tableName, this._logWaiting.params);
+        }
+      },
+
+      _onDisplayIdError: function() {
+        this._displayIdReceived = true;
+
+        if (this._logWaiting) {
+          this.log(this._logWaiting.tableName, this._logWaiting.params);
+        }
+      },
+
       _onTokenResponse: function(e, resp) {
         // in case there are other instances of rise-logger
         e.stopPropagation();
@@ -126,6 +159,14 @@
       },
 
       /**
+       * An instance of the element was inserted into the DOM.
+       */
+      attached: function() {
+        // request the display id from Rise Cache
+        this.$.displayId.generateRequest();
+      },
+
+      /**
        * Logs data to Google Big Query
        *
        */
@@ -138,7 +179,17 @@
           return;
         }
 
-        insertParams = this.$.utils.getInsertParams(params);
+        if (!this._displayIdReceived) {
+          // save the log details so they can be used to execute log() again from displayId handlers
+          this._logWaiting = {
+            tableName: tableName,
+            params: JSON.parse(JSON.stringify(params))
+          };
+
+          return;
+        }
+
+        insertParams = this.$.utils.getInsertParams(params, this._displayId);
 
         if (!insertParams || insertParams.usage_type === "dev") {
           return;

--- a/test/rise-logger-integration.html
+++ b/test/rise-logger-integration.html
@@ -15,9 +15,16 @@
 <rise-logger id="logger"></rise-logger>
 
 <script>
+  var logger = document.querySelector("#logger"),
+    display = "abc123";
+
+  // mock getting display id from Rise Cache
+  sinon.stub(logger.$.displayId, "generateRequest", function() {
+    logger._onDisplayIdResponse(null, {response: {displayId: display}});
+  });
+
   suite("rise-logger", function () {
     var xhr, clock, requests,
-      logger = document.querySelector("#logger"),
       tableName = "test",
       interval = 3580000,
       token = "my-token",
@@ -55,6 +62,7 @@
       xhr.restore();
       clock.restore();
       logger.$.utils._getUsageType.restore();
+      logger.$.displayId.generateRequest.restore();
       logger._refreshToken.restore();
     });
 
@@ -104,7 +112,7 @@
     test("should send string data in the body", function() {
       assert.include(requests[0].requestBody, '{"kind":"bigquery#tableDataInsertAllRequest","skipInvalidRows":false,' +
         '"ignoreUnknownValues":false,"templateSuffix":"' + getDateSuffix() + '","rows":[{"insertId":');
-      assert.include(requests[0].requestBody, '"json":{"event":"' + params.event + '","usage_type":"standalone","ts":');
+      assert.include(requests[0].requestBody, '"json":{"event":"' + params.event + '","display_id":"' + display + '","usage_type":"standalone","ts":');
     });
 
   });

--- a/test/rise-logger-unit.html
+++ b/test/rise-logger-unit.html
@@ -80,6 +80,69 @@
       });
     });
 
+    suite("_onDisplayIdResponse", function () {
+      var logStub;
+
+      var resp = {
+          "response": {
+            "displayId": "abc123"
+          }
+        },
+        e = {
+          "stopPropagation": function () {}
+        };
+
+      setup(function () {
+        logStub = sinon.stub(logger, "log");
+        logger._displayIdReceived = false;
+      });
+
+      teardown(function () {
+        logStub.restore();
+        logger._logWaiting = null;
+      });
+
+      test("should flag display id has been received", function() {
+        logger._onDisplayIdResponse(e, resp);
+
+        assert.isTrue(logger._displayIdReceived);
+      });
+
+      test("should call log() function with saved log params", function () {
+        logger._logWaiting = {tableName: "test", params: {event: "ready"}};
+        logger._onDisplayIdResponse(e, resp);
+
+        assert.isTrue(logStub.calledWith("test", {event: "ready"}));
+      });
+    });
+
+    suite("_onDisplayIdError", function() {
+      var logStub;
+
+      setup(function () {
+        logStub = sinon.stub(logger, "log");
+        logger._displayIdReceived = false;
+      });
+
+      teardown(function () {
+        logStub.restore();
+        logger._logWaiting = null;
+      });
+
+      test("should flag display id has been received", function() {
+        logger._onDisplayIdError();
+
+        assert.isTrue(logger._displayIdReceived);
+      });
+
+      test("should call log() function with saved log params", function () {
+        logger._logWaiting = {tableName: "test", params: {event: "ready"}};
+        logger._onDisplayIdError();
+
+        assert.isTrue(logStub.calledWith("test", {event: "ready"}));
+      });
+    });
+
     suite("_onTokenResponse", function () {
       var insertStub;
 
@@ -147,12 +210,15 @@
 
       setup(function() {
         refreshStub = sinon.stub(logger, "_refreshToken");
+        logger._displayIdReceived = true;
+        logger._displayId = "abc123";
       });
 
       teardown(function() {
         refreshStub.restore();
         logger._throttle = false;
         logger._lastEvent = "";
+        logger._logWaiting = null;
       });
 
       test("should not make a request if table name is empty", function() {
@@ -196,6 +262,21 @@
         });
 
         assert.equal(refreshStub.callCount, 0);
+
+        getInsertStub.restore();
+      });
+
+      test("should not make a request and save log params when display id not received", function() {
+        var getInsertStub = sinon.stub(logger.$.utils, "getInsertParams", insertStandalone);
+
+        logger._displayIdReceived = false;
+
+        logger.log("component_sheet_events", {
+          "event": "ready"
+        });
+
+        assert.equal(refreshStub.callCount, 0);
+        assert.deepEqual(logger._logWaiting, {tableName: "component_sheet_events", params: {"event": "ready"}});
 
         getInsertStub.restore();
       });

--- a/test/rise-logger-utils-unit.html
+++ b/test/rise-logger-utils-unit.html
@@ -87,15 +87,15 @@
     suite("getInsertParams", function () {
 
       test("should return null when event param missing", function () {
-        assert.isNull(utils.getInsertParams({"event_details": "test"}));
+        assert.isNull(utils.getInsertParams({"event_details": "test"}, "abc123"));
       });
 
-      test("should return correct params including usage_type", function () {
+      test("should return correct params", function () {
         var data;
 
         sinon.stub(utils, "_getUsageType", function () { return "standalone"});
 
-        data = utils.getInsertParams({event: "ready", display_id: "abc123"});
+        data = utils.getInsertParams({event: "ready"}, "abc123");
 
         assert.deepEqual(data, {
           event: "ready",


### PR DESCRIPTION
- Making request to "displays" endpoint of Rise Cache and using value of `displayId` in response to log with
- Ensuring a log request waits until the request for a display id has completed
- Added unit and integration tests
