### PR TITLE
Applying usage_type value if provided in log() params

### DIFF
--- a/rise-logger-utils.html
+++ b/rise-logger-utils.html
@@ -12,10 +12,6 @@
 
     "use strict";
 
-    var USAGE_DEV = "dev",
-      USAGE_STANDALONE = "standalone",
-      USAGE_WIDGET = "widget";
-
     Polymer({
       is: "rise-logger-utils",
 
@@ -42,15 +38,12 @@
 
       _getUsageType: function(href) {
         var a = document.createElement("a"),
-          type = USAGE_STANDALONE;
+          type = "standalone";
 
         a.href = href;
 
         if (a.hostname === "localhost") {
-          type = USAGE_DEV;
-        }
-        else if (a.hostname === "s3.amazonaws.com" && a.pathname.indexOf("widget-") > -1) {
-          type = USAGE_WIDGET;
+          type = "dev";
         }
 
         return type;
@@ -95,7 +88,7 @@
           json.display_id = displayId;
 
           // add the usage type
-          json.usage_type = this._getUsageType(window.location.href);
+          json.usage_type = json.usage_type || this._getUsageType(window.location.href);
         }
 
         return json;

--- a/test/rise-logger-utils-unit.html
+++ b/test/rise-logger-utils-unit.html
@@ -24,11 +24,7 @@
         assert.equal(utils._getUsageType("http://localhost:8000/#/preview/widget"), "dev");
       });
 
-      test("should return 'widget'", function () {
-        assert.equal(utils._getUsageType("http://s3.amazonaws.com/widget-google-spreadsheet/2.0.0/dist/widget.html"), "widget");
-      });
-
-      test("should return 'standalone'", function () {
+      test("should return 'standalone' by default", function () {
         assert.equal(utils._getUsageType("https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/test/content.html"), "standalone");
       });
 
@@ -91,6 +87,18 @@
       });
 
       test("should return correct params", function () {
+        var data;
+
+        data = utils.getInsertParams({event: "ready", usage_type: "widget"}, "abc123");
+
+        assert.deepEqual(data, {
+          event: "ready",
+          usage_type: "widget",
+          display_id: "abc123"
+        });
+      });
+
+      test("should return correct params when no 'usage_type' provided", function () {
         var data;
 
         sinon.stub(utils, "_getUsageType", function () { return "standalone"});


### PR DESCRIPTION
- Removing logic for determining usage type to be "widget" and instead allowing the usage type to be provided in the params when calling `log()`
- Unit tests revised and added
