### PR TITLE
Fire event when display id received from Rise Cache

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-logger",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "authors": [
     "Rise Vision"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-logger",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Rise Vision web component used for logging usage of a parent web component",
   "scripts": {
     "test": "gulp test",

--- a/rise-logger.html
+++ b/rise-logger.html
@@ -102,6 +102,12 @@ The following illustrates how to use `rise-logger` within a parent Rise Vision w
         }
       },
 
+      /**
+       * Fired when Rise Cache responds providing a display id
+       *
+       * @event rise-logger-display-id
+       */
+
       _logWaiting: null,
 
       _displayId: "",
@@ -152,6 +158,7 @@ The following illustrates how to use `rise-logger` within a parent Rise Vision w
         }
 
         this._displayIdReceived = true;
+        this.fire("rise-logger-display-id", this._displayId);
 
         if (this._logWaiting) {
           this.log(this._logWaiting.tableName, this._logWaiting.params);
@@ -160,6 +167,7 @@ The following illustrates how to use `rise-logger` within a parent Rise Vision w
 
       _onDisplayIdError: function() {
         this._displayIdReceived = true;
+        this.fire("rise-logger-display-id");
 
         if (this._logWaiting) {
           this.log(this._logWaiting.tableName, this._logWaiting.params);

--- a/test/rise-logger-unit.html
+++ b/test/rise-logger-unit.html
@@ -100,12 +100,28 @@
       teardown(function () {
         logStub.restore();
         logger._logWaiting = null;
+        logger._displayId = "";
       });
 
       test("should flag display id has been received", function() {
         logger._onDisplayIdResponse(e, resp);
 
         assert.isTrue(logger._displayIdReceived);
+      });
+
+      test("should fire 'rise-logger-display-id' event", function(done) {
+        var listener = function(response) {
+          responded = true;
+          assert.equal(resp.response.displayId, response.detail);
+          logger.removeEventListener("rise-logger-display-id", listener);
+        },
+          responded = false;
+
+        logger.addEventListener("rise-logger-display-id", listener);
+        logger._onDisplayIdResponse(e, resp);
+
+        assert.isTrue(responded);
+        done();
       });
 
       test("should call log() function with saved log params", function () {
@@ -133,6 +149,20 @@
         logger._onDisplayIdError();
 
         assert.isTrue(logger._displayIdReceived);
+      });
+
+      test("should fire 'rise-logger-display-id' event", function(done) {
+        var listener = function() {
+            responded = true;
+            logger.removeEventListener("rise-logger-display-id", listener);
+          },
+          responded = false;
+
+        logger.addEventListener("rise-logger-display-id", listener);
+        logger._onDisplayIdError();
+
+        assert.isTrue(responded);
+        done();
       });
 
       test("should call log() function with saved log params", function () {


### PR DESCRIPTION
- Firing "rise-logger-display-id" with the display id (if provided) when Rise Cache responds from "displayId" request
- Unit tests added
- Minor patch version bump