### PR TITLE
Ensure log() not called again when no queued items left

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-logger",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "authors": [
     "Rise Vision"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-logger",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Rise Vision web component used for logging usage of a parent web component",
   "scripts": {
     "test": "gulp test",

--- a/rise-logger.html
+++ b/rise-logger.html
@@ -155,12 +155,13 @@ The following illustrates how to use `rise-logger` within a parent Rise Vision w
       },
 
       _nextLogWaiting: function() {
-        var self = this;
+        var self = this,
+          item;
 
-        if ( this._logsWaiting.length > 0 ) {
+        if (this._logsWaiting.length > 0) {
+          item = this._logsWaiting.shift();
+
           this.debounce( "queue", function() {
-            var item = self._logsWaiting.shift();
-
             self.log( item.tableName, item.params );
             self._nextLogWaiting();
           }, this._throttleDelay + 250 );

--- a/test/rise-logger-unit.html
+++ b/test/rise-logger-unit.html
@@ -110,6 +110,20 @@
         assert.equal( logger._logsWaiting.length, 0 );
       } );
 
+      test( "should not call log() again after removing all queued items", function() {
+        logger._logsWaiting = [ {
+          tableName: "test", params: { event: "ready" }
+        }, {
+          tableName: "test2", params: { event: "error" }
+        } ];
+        logger._nextLogWaiting();
+
+        // simulate debounce and progress time more than 3 possible items
+        clock.tick( 6000 );
+
+        assert.isTrue( logStub.calledTwice );
+      } );
+
       test( "should not call log() if no queued items", function() {
         logger._nextLogWaiting();
 


### PR DESCRIPTION
- Fixing reference to `_logsWaiting` property in `_nextLogWaiting()` function when removing a queued item
- Unit test added
- Minor patch version bump