### PR TITLE
Use http:// protocol for rise cache displays/ endpoint

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-logger",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "authors": [
     "Rise Vision"
   ],

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -17,7 +17,7 @@
   } );
 
   gulp.task( "lint", function() {
-    return gulp.src( [ "./*.js", "test/**/*.html" ] )
+    return gulp.src( [ "./**/*.js", "./**/*.html" ] )
       .pipe( eslint() )
       .pipe( eslint.format() )
       .pipe( eslint.failAfterError() );

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,6 +8,7 @@
     del = require( "del" ),
     eslint = require( "gulp-eslint" ),
     gulp = require( "gulp" ),
+    htmlreplace = require( "gulp-html-replace" ),
     runSequence = require( "run-sequence" ),
     wct = require( "web-component-tester" ).gulp.init( gulp ); // eslint-disable-line
 
@@ -20,6 +21,19 @@
       .pipe( eslint() )
       .pipe( eslint.format() )
       .pipe( eslint.failAfterError() );
+  } );
+
+  gulp.task( "version", function() {
+    var pkg = require( "./package.json" );
+
+    gulp.src( "./rise-logger.html" )
+      .pipe( htmlreplace( {
+        "version": {
+          src: pkg.version,
+          tpl: "<script>var loggerVersion = \"%s\";</script>"
+        }
+      }, { keepBlockTags: true } ) )
+      .pipe( gulp.dest( "./" ) );
   } );
 
   // ***** Primary Tasks ***** //
@@ -40,7 +54,7 @@
     runSequence( "test:local", cb );
   } );
 
-  gulp.task( "build", function( cb ) {
+  gulp.task( "build", [ "version" ], function( cb ) {
     runSequence( "lint", cb );
   } );
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-logger",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Rise Vision web component used for logging usage of a parent web component",
   "scripts": {
     "test": "gulp test",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "gulp-bower": "~0.0.10",
     "gulp-bump": "~0.2.0",
     "gulp-eslint": "^3.0.1",
+    "gulp-html-replace": "~1.6.1",
     "run-sequence": "~1.1.0",
     "web-component-tester": "*",
     "widget-tester": "git://github.com/Rise-Vision/widget-tester.git"

--- a/rise-logger.html
+++ b/rise-logger.html
@@ -64,7 +64,7 @@ The following illustrates how to use `rise-logger` within a parent Rise Vision w
 </dom-module>
 
 <!-- build:version -->
-<script>var loggerVersion = "1.0.3";</script>
+<script>var loggerVersion = "1.0.4";</script>
 <!-- endbuild -->
 
 <script>

--- a/rise-logger.html
+++ b/rise-logger.html
@@ -63,6 +63,10 @@ The following illustrates how to use `rise-logger` within a parent Rise Vision w
   </template>
 </dom-module>
 
+<!-- build:version -->
+<script>var loggerVersion = "1.0.3";</script>
+<!-- endbuild -->
+
 <script>
   ( function() {
     /* global Polymer */

--- a/rise-logger.html
+++ b/rise-logger.html
@@ -45,7 +45,7 @@ The following illustrates how to use `rise-logger` within a parent Rise Vision w
   <template>
     <rise-logger-utils id="utils"></rise-logger-utils>
     <iron-ajax id="displayId"
-               url="//localhost:9494/displays"
+               url="http://localhost:9494/displays"
                handle-as="json"
                on-response="_onDisplayIdResponse"
                on-error="_onDisplayIdError"

--- a/rise-logger.html
+++ b/rise-logger.html
@@ -162,7 +162,7 @@ The following illustrates how to use `rise-logger` within a parent Rise Vision w
         var self = this,
           item;
 
-        if (this._logsWaiting.length > 0) {
+        if ( this._logsWaiting.length > 0 ) {
           item = this._logsWaiting.shift();
 
           this.debounce( "queue", function() {


### PR DESCRIPTION
- Injecting version into component code to be consistent with other rise components
- Using `http://` protocol for rise cache `displays/` endpoint
- Version bump