### PR TITLE
Enabling logging via Player

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-logger",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "authors": [
     "Rise Vision"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-logger",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Rise Vision web component used for logging usage of a parent web component",
   "scripts": {
     "test": "gulp test",

--- a/rise-logger-utils.html
+++ b/rise-logger-utils.html
@@ -92,6 +92,19 @@
         }
 
         return json;
+      },
+
+      logEventToPlayer: function( table, params ) {
+        try {
+          top.postToPlayer( {
+            message: "widget-log",
+            table: table,
+            params: JSON.stringify( params ),
+            suffix: this._getSuffix()
+          } );
+        } catch ( err ) {
+          console.log( "rise-logger.logEventToPlayer", err ); // eslint-disable-line no-console
+        }
       }
 
     } );

--- a/rise-logger.html
+++ b/rise-logger.html
@@ -64,7 +64,7 @@ The following illustrates how to use `rise-logger` within a parent Rise Vision w
 </dom-module>
 
 <!-- build:version -->
-<script>var loggerVersion = "1.0.8";</script>
+<script>var loggerVersion = "1.0.9";</script>
 <!-- endbuild -->
 
 <script>
@@ -273,10 +273,21 @@ The following illustrates how to use `rise-logger` within a parent Rise Vision w
           return;
         }
 
+        // don't log if display id is invalid or preview/local
+        if ( !this._displayId || this._displayId === "preview" || this._displayId === "display_id" ||
+          this._displayId === "displayId" ) {
+          return;
+        }
+
         insertParams = this.$.utils.getInsertParams( params, this._displayId );
 
         if ( !insertParams || insertParams.usage_type === "dev" ) {
           return;
+        }
+
+        if ( top.postToPlayer && top.enableWidgetLogging ) {
+          // send log data to player instead of BQ
+          return this.$.utils.logEventToPlayer( tableName, insertParams );
         }
 
         this._throttle = true;

--- a/test/rise-logger-unit.html
+++ b/test/rise-logger-unit.html
@@ -302,6 +302,8 @@
         refreshStub = sinon.stub( logger, "_refreshToken" );
         logger._displayIdReceived = true;
         logger._displayId = "abc123";
+        top.postToPlayer = undefined;
+        top.enableWidgetLogging = false;
       } );
 
       teardown( function() {
@@ -377,6 +379,39 @@
         } ] );
 
         getInsertStub.restore();
+      } );
+
+      test( "should not make a request if the display id value is invalid", function() {
+        var getInsertStub = sinon.stub( logger.$.utils, "getInsertParams", insertStandalone );
+
+        logger._displayId = "preview";
+
+        logger.log( "component_sheet_events", {
+          "event": "ready"
+        } );
+
+        assert.equal( refreshStub.callCount, 0 );
+
+        getInsertStub.restore();
+      } );
+
+      test( "should call utils 'logEventtoPlayer' when enableWidgetLogging exists", function() {
+        var getInsertStub = sinon.stub( logger.$.utils, "getInsertParams", insertStandalone ),
+          logToPlayerStub = sinon.stub( logger.$.utils, "logEventToPlayer" );
+
+        top.postToPlayer = function() {};
+        top.enableWidgetLogging = true;
+
+        logger.log( "component_sheet_events", {
+          "event": "ready"
+        } );
+
+        assert.equal( logToPlayerStub.args[ 0 ][ 0 ], "component_sheet_events" );
+        assert.deepEqual( logToPlayerStub.args[ 0 ][ 1 ], { event: "ready", usage_type: "standalone" } );
+        assert.equal( refreshStub.callCount, 0 );
+
+        getInsertStub.restore();
+        logToPlayerStub.restore();
       } );
 
       test( "should not log the same event multiple times if the time between calls is less than 1 second", function() {

--- a/test/rise-logger-utils-unit.html
+++ b/test/rise-logger-utils-unit.html
@@ -117,6 +117,33 @@
 
         utils._getUsageType.restore();
       } );
+    } );
+
+    suite( "logEventToPlayer", function() {
+      var tableName = "component_sheet_events",
+        params = {
+          "event": "ready",
+          "event_details": "testing",
+          "usage_type": "standalone",
+          "display_id": "abc123"
+        };
+
+      suiteSetup( function() {
+        top.postToPlayer = function() {};
+      } );
+
+      test( "should call postToPlayer on top window with correct parameters", function() {
+        var postStub = sinon.stub( top, "postToPlayer" );
+
+        utils.logEventToPlayer( tableName, utils.getInsertParams( params, "abc123" ) );
+
+        assert.equal( postStub.args[ 0 ][ 0 ].message, "widget-log" );
+        assert.equal( postStub.args[ 0 ][ 0 ].table, tableName );
+        assert.equal( postStub.args[ 0 ][ 0 ].params, JSON.stringify( params ) );
+        assert.property( postStub.args[ 0 ][ 0 ], "suffix" );
+
+        top.postToPlayer.restore();
+      } );
 
     } );
 


### PR DESCRIPTION
- Will only log with a valid display id
- Will log via player if `enableWidgetLogging` present in top window, otherwise log directly to BQ