### PR TITLE
Leverage "ready" hook instead of "attached"

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-logger",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "authors": [
     "Rise Vision"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-logger",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Rise Vision web component used for logging usage of a parent web component",
   "scripts": {
     "test": "gulp test",

--- a/rise-logger.html
+++ b/rise-logger.html
@@ -64,7 +64,7 @@ The following illustrates how to use `rise-logger` within a parent Rise Vision w
 </dom-module>
 
 <!-- build:version -->
-<script>var loggerVersion = "1.0.11";</script>
+<script>var loggerVersion = "1.0.12";</script>
 <!-- endbuild -->
 
 <script>
@@ -253,11 +253,25 @@ The following illustrates how to use `rise-logger` within a parent Rise Vision w
         this.$.token.generateRequest();
       },
 
+      _startTests: function() {
+        // ensure to not execute code below if this integration test flag is not set
+        if ( !window.riseLoggerTests ) {
+          return;
+        }
+
+        this.ready( true );
+      },
+
       /**
-       * An instance of the element was inserted into the DOM.
+       * Polymer has finished its initialization. This is the entry point.
        */
-      attached: function() {
+      ready: function( runningTests ) {
         var protocol = ( this._isRiseCacheSchemeEnabled() ) ? "rchttps://" : "https://";
+
+        // Necessary for integration tests so this function doesn't execute code below before stubs can be created
+        if ( window.riseLoggerTests && !runningTests ) {
+          return;
+        }
 
         this._displayIdBaseUrl = protocol + "localhost:9495/displays";
         // request the display id from Rise Cache

--- a/test/rise-logger-integration.html
+++ b/test/rise-logger-integration.html
@@ -7,6 +7,10 @@
 
   <script src="../bower_components/webcomponentsjs/webcomponents.min.js"></script>
   <script src="../bower_components/web-component-tester/browser.js"></script>
+  <script>
+    // global flag that rise-logger checks on ready handler for determining if running in an integration test
+    window.riseLoggerTests = true;
+  </script>
 
   <link rel="import" href="../rise-logger.html">
 </head>
@@ -17,7 +21,7 @@
 <script>
   /* global sinon, suite, test, assert, setup, suiteSetup, suiteTeardown */
 
-  var logger = document.querySelector( "#logger" ),
+  var logger = document.querySelector( "#logger" ), // eslint-disable-line vars-on-top
     display = "abc123";
 
   // mock getting display id from Rise Cache
@@ -59,6 +63,9 @@
           "response": data
         } )
       } );
+
+      // required for integration test
+      logger._startTests();
     } );
 
     suiteTeardown( function() {

--- a/test/rise-logger-unit.html
+++ b/test/rise-logger-unit.html
@@ -325,7 +325,7 @@
 
     } );
 
-    suite( "attached", function() {
+    suite( "ready", function() {
 
       suiteSetup( function() {
         sinon.stub( logger.$.displayId, "generateRequest" );
@@ -339,14 +339,14 @@
 
       test( "should set display id request url to use 'rchttps' scheme", function() {
         top.enableRiseCacheScheme = true;
-        logger.attached();
+        logger.ready();
 
         assert.isTrue( logger.$.displayId.url.startsWith( "rchttps://" ) );
       } );
 
       test( "should set display id request url to not use 'rchttp' scheme", function() {
         top.enableRiseCacheScheme = false;
-        logger.attached();
+        logger.ready();
 
         assert.isTrue( logger.$.displayId.url.startsWith( "https://" ) );
       } );


### PR DESCRIPTION
- This is to fix the issue with Spreadsheet widget running in Preview on Chrome 67 whereby `attached` in this component is not firing. 
- Integration tests required fixing to prevent code from executing before any sinon test stubs could be created